### PR TITLE
Handle edge case when attribute value is an empty string and the type is a date or time

### DIFF
--- a/lib/delocalize/rails_ext/action_view_rails4.rb
+++ b/lib/delocalize/rails_ext/action_view_rails4.rb
@@ -27,7 +27,7 @@ ActionView::Helpers::Tags::TextField.class_eval do
           @options[:value] = number_with_precision(value, opts) unless hidden_for_integer
         end
       elsif column.date? || column.time?
-        @options[:value] = value ? I18n.l(value, :format => @options.delete(:format)) : nil
+        @options[:value] = value.present? ? I18n.l(value, :format => @options.delete(:format)) : nil
       end
     end
 


### PR DESCRIPTION
This is possible when the callers of `render` use the attribute's value _before type casting_. Specifically this occurred with an `ActiveRecord::BaseWithoutTable` object having a `date` attribute (with an empty string value) rendered by the `calendar_date_select` form helper gem. [Here](https://github.com/timcharper/calendar_date_select/blob/master/app/helpers/calendar_date_select/form_helpers.rb#L135) is where the value before type cast is captured; it is later used when invoking [this line](https://github.com/timcharper/calendar_date_select/blob/master/app/helpers/calendar_date_select/form_helpers.rb#L148).

Furthermore, note the behaviour of `ActiveRecord::BaseWithoutTable`, described via the spec below:

```ruby
  class Person < ActiveRecord::BaseWithoutTable
    column :birthdate, :date
  end

  def test_handling_nils_for_date
    person = Person.new(birthdate: "")

    assert_equal "", person.birthdate_before_type_cast
    assert_equal nil, person.birthdate
  end
```