### PR TITLE
update ruby version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ rvm:
   - 2.3.4
   - 2.2.7
   - 2.1.10
-  - jruby-9.1.8.0
-  - rbx-2
+  - 2.1.6
 
 gemfile:
   - ci/Gemfile.rails42
@@ -24,6 +23,5 @@ matrix:
     # Rails 5.0 needs Ruby > 2.2.2
     - rvm: 2.1.10
       gemfile: ci/Gemfile.rails50
-  allow_failures:
-    - rvm: rbx-2
-    - rvm: jruby-9.1.8.0
+    - rvm: 2.1.6
+      gemfile: ci/Gemfile.rails50

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # delocalize
 
-[![Build Status](https://secure.travis-ci.org/clemens/delocalize.png)](http://travis-ci.org/clemens/delocalize)
+[![Build Status](https://travis-ci.org/nulogy/nu-delocalize.svg?branch=master)](https://travis-ci.org/nulogy/nu-delocalize)
 
 delocalize provides localized date/time and number parsing functionality for Rails.
 


### PR DESCRIPTION
Adjusting Ruby versions for CI.
Dropped rubinius and jruby testing (it was under `allow_failures` anyways).
