### PR TITLE
Fix column for attribute deprecation warnings

### DIFF
--- a/lib/delocalize/rails_ext/action_view_rails4.rb
+++ b/lib/delocalize/rails_ext/action_view_rails4.rb
@@ -7,8 +7,9 @@ ActionView::Helpers::Tags::TextField.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def render_with_localization
-    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && object.respond_to?(:column_for_attribute) && column = object.column_for_attribute(@method_name)
+    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && object.has_attribute?(@method_name)
       value = @options[:value] || object.send(@method_name)
+      column = object.column_for_attribute(@method_name)
 
       if column.number?
         number_options = I18n.t(:'number.format')

--- a/lib/delocalize/version.rb
+++ b/lib/delocalize/version.rb
@@ -1,3 +1,3 @@
 module Delocalize
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Fixes Rails 4.2 deprecation warnings:

```
DEPRECATION WARNING: `#column_for_attribute` will return a null object for non-existent columns in Rails 5. Use `#has_attribute?` if you need to check for an attribute's existence. (called from render_with_localization at ~/some_path/gems/nu-delocalize-f78d0428cdba/lib/delocalize/rails_ext/action_view_rails4.rb:10)
```