### PR TITLE
More defensive of column access

### DIFF
--- a/lib/delocalize.rb
+++ b/lib/delocalize.rb
@@ -8,4 +8,11 @@ module Delocalize
   class ParserNotFound < ArgumentError; end
 
   autoload :Parsers, 'delocalize/parsers'
+
+  # this ensures that a subsequent call to `column_for_attribute` will return a column and not nil
+  def self.model_has_column?(model, column_name)
+    return false unless model.respond_to?(:has_attribute?) && model.has_attribute?(column_name)
+
+    model.class.columns.any? { |e| e.name == column_name }
+  end
 end

--- a/lib/delocalize.rb
+++ b/lib/delocalize.rb
@@ -12,6 +12,7 @@ module Delocalize
   # this ensures that a subsequent call to `column_for_attribute` will return a column and not nil
   def self.model_has_column?(model, column_name)
     return false unless model.respond_to?(:has_attribute?) && model.has_attribute?(column_name)
+    return false unless model.class.respond_to?(:columns)
 
     model.class.columns.any? { |e| e.name == column_name }
   end

--- a/lib/delocalize/rails_ext/action_view_rails4.rb
+++ b/lib/delocalize/rails_ext/action_view_rails4.rb
@@ -7,7 +7,7 @@ ActionView::Helpers::Tags::TextField.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def render_with_localization
-    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && safe_has_attribute?(object, @method_name)
+    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && Delocalize.model_has_column?(object, @method_name)
       value = @options[:value] || object.send(@method_name)
       column = object.column_for_attribute(@method_name)
 
@@ -36,10 +36,4 @@ ActionView::Helpers::Tags::TextField.class_eval do
   end
 
   alias_method_chain :render, :localization
-
-  private
-
-  def safe_has_attribute?(model, attribute_name)
-    model.respond_to?(:has_attribute?) && model.has_attribute?(attribute_name)
-  end
 end

--- a/lib/delocalize/rails_ext/active_record_rails4.rb
+++ b/lib/delocalize/rails_ext/active_record_rails4.rb
@@ -23,7 +23,7 @@ end
 ActiveRecord::Base.class_eval do
   def write_attribute_with_localization(attr_name, original_value)
     new_value = original_value
-    if model_has_column?(self, attr_name.to_s)
+    if Delocalize.model_has_column?(self, attr_name.to_s)
       column = column_for_attribute(attr_name.to_s)
 
       if column.date?
@@ -40,7 +40,7 @@ ActiveRecord::Base.class_eval do
   # In Rails 4.2.8,  _field_changed?(attr, old)
   if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR < 2
     define_method :_field_changed? do |attr, old, value|
-      if model_has_column?(self, attr)
+      if Delocalize.model_has_column?(self, attr)
         column = column_for_attribute(attr)
 
         if column.number? && column.null && (old.nil? || old == 0) && value.blank?
@@ -62,7 +62,7 @@ ActiveRecord::Base.class_eval do
     define_method :_field_changed? do |attr, old_value|
       delocalized_old_value = old_value
 
-      if model_has_column?(self, attr)
+      if Delocalize.model_has_column?(self, attr)
         column = column_for_attribute(attr)
 
         if column.number?
@@ -91,14 +91,5 @@ ActiveRecord::Base.class_eval do
     else
       super
     end
-  end
-
-  private
-
-  # this ensures that a subsequent call to `column_for_attribute` will return a column and not nil
-  def model_has_column?(model, column_name)
-    return false unless model.respond_to?(:has_attribute?) && model.has_attribute?(column_name)
-
-    model.class.columns.any? { |e| e.name == column_name }
   end
 end


### PR DESCRIPTION
Very very defensive... all sorts of objects could be passed through the `ActionView` helper, or inherit `ActiveRecord`-like methods, but have no backing database columns for its attributes.